### PR TITLE
Remove raise and handle reconnection

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -520,6 +520,27 @@ defmodule KafkaEx do
   end
 
   @doc """
+  Check to see if worker (server) is ready and connected
+
+  Optional arguments(KeywordList)
+  - worker_name: the worker we want to run this metadata request through, when none is provided the default worker `:kafka_ex` is used
+
+  ## Example
+
+  ```
+  iex> KafkaEx.ready?()
+  false
+  iex> KafkaEx.ready?(:kafka_ex)
+  true
+  ```
+  """
+
+  @spec ready?(atom | pid) :: boolean
+  def ready?(worker \\ Config.default_worker) do
+    Server.call(worker, :ready_check)
+  end
+
+  @doc """
   Returns true if the input is a valid consumer group or :no_consumer_group
   """
   @spec valid_consumer_group?(any) :: boolean

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -403,16 +403,21 @@ defmodule KafkaEx.ConsumerGroup.Manager do
       member_id: member_id,
     }
 
-    leave_group_response =
-      KafkaEx.leave_group(leave_request, worker_name: worker_name)
 
-    if leave_group_response.error_code == :no_error do
-      Logger.debug(fn -> "Left consumer group #{group_name}" end)
-    else
-      Logger.warn(fn ->
-        "Received error #{inspect leave_group_response.error_code}, " <>
-        "consumer group manager will exit regardless."
-      end)
+    try do
+      leave_group_response =
+        KafkaEx.leave_group(leave_request, worker_name: worker_name)
+
+      if leave_group_response.error_code == :no_error do
+        Logger.debug(fn -> "Left consumer group #{group_name}" end)
+      else
+        Logger.warn(fn ->
+          "Received error #{inspect leave_group_response.error_code}, " <>
+          "consumer group manager will exit regardless."
+        end)
+      end
+    catch
+      :exit, _ -> IO.puts "RESCUED"
     end
 
     {:ok, state}

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -35,6 +35,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
       :generation_id,
       :assignments,
       :heartbeat_timer,
+      :worker_opts,
     ]
     @type t :: %__MODULE__{}
   end
@@ -42,6 +43,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   @heartbeat_interval 5_000
   @session_timeout 30_000
   @session_timeout_padding 5_000
+  @startup_delay 100
 
   @type assignments :: [{binary(), integer()}]
 
@@ -93,14 +95,9 @@ defmodule KafkaEx.ConsumerGroup.Manager do
     )
 
     worker_opts = Keyword.take(opts, [:uris])
-    {:ok, worker_name} = KafkaEx.create_worker(
-      :no_name,
-      [consumer_group: group_name] ++ worker_opts
-    )
 
     state = %State{
       supervisor_pid: supervisor_pid,
-      worker_name: worker_name,
       heartbeat_interval: heartbeat_interval,
       session_timeout: session_timeout,
       consumer_module: consumer_module,
@@ -108,12 +105,12 @@ defmodule KafkaEx.ConsumerGroup.Manager do
       consumer_opts: consumer_opts,
       group_name: group_name,
       topics: topics,
-      member_id: nil,
+      worker_opts: worker_opts
     }
 
-    Process.flag(:trap_exit, true)
+    Process.send_after(self(), :init_start_worker, @startup_delay)
 
-    {:ok, state, 0}
+    {:ok, state}
   end
 
   ######################################################################
@@ -147,15 +144,115 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   end
   ######################################################################
 
+  # `init_start_worker` - stage 1/4 of connecting, during the `init/1`
+  # callback, it fires a message to do this, which means if this fails, it can be re-tried by
+  # sending the same message
+  def handle_info(
+    :init_start_worker, %State{group_name: group_name, worker_opts: worker_opts} = state
+  ) do
+    Logger.debug(fn -> "Phase 1/4 - broker connection" end)
+
+    res = KafkaEx.create_worker(
+      :no_name,
+      [consumer_group: group_name] ++ worker_opts
+    )
+
+    case res do
+      {:ok, worker_name} ->
+        state = %State{state | worker_name: worker_name}
+
+        Process.flag(:trap_exit, true)
+
+        # Move onto second stage of init, which can fail separately from this
+        # connection, see below for more details
+        # Process.send_after(self(), :init_join_group, @startup_delay)
+
+        Process.send_after(self(), :init_wait_for_server, @startup_delay)
+
+        {:noreply, state}
+
+      {:error, {:already_started, _pid}} ->
+        Process.flag(:trap_exit, true)
+
+        Process.send_after(self(), :init_wait_for_server, @startup_delay)
+
+        {:noreply, state}
+
+      {:error, _reason} ->
+        # We dont need to stop_worker here, as it exits itself
+        #   12:54:00.356 [error] CRASH REPORT Process <0.745.0> with 0 neighbours exited with reason:
+        # As the call to KafkaEx.create_worker/2 starts a Server* as a child process via Supervisor.start_child
+        # but if it fails within the init/1, it returns {:stop, reason} which exits that process for us
+
+        # Re-attempt this stage
+        Process.send_after(self(), :init_start_worker, @startup_delay)
+        {:noreply, state}
+    end
+  end
+
+  # phase 2/4
+  def handle_info(:init_wait_for_server, %State{worker_name: worker_name} = state) do
+    Logger.debug(fn -> "Phase 2/4 - broker connection" end)
+    if KafkaEx.ready?(worker_name) do
+      Process.send_after(self(), :init_join_group, @startup_delay)
+    else
+      Process.send_after(self(), :init_wait_for_server, @startup_delay)
+    end
+
+     {:noreply, state}
+  end
+
+  # `init_join_group` - phase 3/4
   # If `member_id` and `generation_id` aren't set, we haven't yet joined the
   # group. `member_id` and `generation_id` are initialized by
   # `JoinGroupResponse`.
   def handle_info(
-    :timeout, %State{generation_id: nil, member_id: nil} = state
+    :init_join_group, %State{generation_id: nil, member_id: nil} = state
   ) do
-    {:ok, new_state} = join(state)
+    Logger.debug(fn -> "Phase 3/4 - partition assignments" end)
+    case join(state) do
+      {:ok, new_state} ->
+        # move onto next stage, if `join/1` has set `assignments` then we are done
+        Process.send_after(self(), :init_assign_partitions, @startup_delay)
+        {:noreply, new_state}
 
-    {:noreply, new_state}
+      {:error, _reason} ->
+        # retry join
+        Process.send_after(self(), :init_join_group, @startup_delay)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(:init_join_group, %State{} = state) do
+    {:noreply, state}
+  end
+
+  # `init_assign_partitions` - phase 4/4
+  # If `assignments` is nil, it means we've not done partitions assignment
+  # Leader is responsible for assigning partitions to all group members.
+  def handle_info(
+    :init_assign_partitions, %State{assignments: nil, members: members} = state
+  ) when not is_nil(members) do
+    Logger.debug(fn -> "Phase 4/4 - partition assignments" end)
+    case assignable_partitions(state) do
+      [] ->
+        Process.send_after(self(), :init_assign_partitions, @startup_delay)
+        {:noreply, state}
+
+      partitions ->
+        assignments = assign_partitions(state, members, partitions)
+        {:ok, new_state} = sync(state, assignments)
+        Logger.debug(fn -> "Connection complete" end)
+        {:noreply, new_state}
+    end
+  end
+
+  def handle_info(:init_assign_partitions, %State{assignments: []} = state) do
+    {:noreply, state}
+  end
+
+  def handle_info(:init_assign_partitions, %State{} = state) do
+    {:noreply, state}
   end
 
   # If the heartbeat gets an error, we need to rebalance.
@@ -212,32 +309,30 @@ defmodule KafkaEx.ConsumerGroup.Manager do
       timeout: session_timeout + @session_timeout_padding
     )
 
-    # crash the worker if we recieve an error, but do it with a meaningful
-    # error message
     if join_response.error_code != :no_error do
-      raise "Error joining consumer group #{group_name}: " <> "#{inspect join_response.error_code}"
-    end
+      message = "Error joining consumer group #{group_name}: " <> "#{inspect join_response.error_code}"
+      Logger.error(message)
+      {:error, join_response.error_code}
+    else
+      Logger.debug(fn -> "Joined consumer group #{group_name}" end)
 
-    Logger.debug(fn -> "Joined consumer group #{group_name}" end)
+      new_state = %State{
+        state |
+        leader_id: join_response.leader_id,
+        member_id: join_response.member_id,
+        generation_id: join_response.generation_id,
+        members: join_response.members
+      }
 
-    new_state = %State{
-      state |
-      leader_id: join_response.leader_id,
-      member_id: join_response.member_id,
-      generation_id: join_response.generation_id
-    }
-
-    assignments =
       if JoinGroupResponse.leader?(join_response) do
         # Leader is responsible for assigning partitions to all group members.
-        partitions = assignable_partitions(new_state)
-        assign_partitions(new_state, join_response.members, partitions)
+
+        {:ok, new_state}
       else
         # Follower does not assign partitions; must be empty.
-        []
+        sync(new_state, [])
       end
-
-    sync(new_state, assignments)
+    end
   end
 
   # `SyncGroupRequest` is used to distribute partition assignments to all group

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -266,10 +266,10 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   # the group so that the group can rebalance without waiting for a session
   # timeout.
   def terminate(_reason, %State{generation_id: nil, member_id: nil}), do: :ok
-  def terminate(_reason, %State{} = state) do
+  def terminate(reason, %State{worker_name: worker_name} = state) do
     {:ok, _state} = leave(state)
-    Process.unlink(state.worker_name)
-    KafkaEx.stop_worker(state.worker_name)
+    Process.unlink(worker_name)
+    KafkaEx.stop_worker(worker_name)
   end
 
   ### Helpers

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -554,17 +554,16 @@ defmodule KafkaEx.GenConsumer do
     :timeout,
     %State{current_offset: nil, last_commit: nil, worker_name: worker_name} = state
   ) do
-    new_state =
-      if KafkaEx.ready?(worker_name) do
-        %State{
-          load_offsets(state) |
-          last_commit: :erlang.monotonic_time(:milli_seconds)
-        }
-      else
-        state
-      end
+    if KafkaEx.ready?(worker_name) do
 
-    {:noreply, new_state, 0}
+      new_state = %State{
+        load_offsets(state) |
+        last_commit: :erlang.monotonic_time(:milli_seconds)
+      }
+      {:noreply, new_state, 0}
+    else
+      {:noreply, state, 0}
+    end
   end
 
   def handle_info(:timeout, %State{} = state) do

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -552,12 +552,17 @@ defmodule KafkaEx.GenConsumer do
 
   def handle_info(
     :timeout,
-    %State{current_offset: nil, last_commit: nil} = state
+    %State{current_offset: nil, last_commit: nil, worker_name: worker_name} = state
   ) do
-    new_state = %State{
-      load_offsets(state) |
-      last_commit: :erlang.monotonic_time(:milli_seconds)
-    }
+    new_state =
+      if KafkaEx.ready?(worker_name) do
+        %State{
+          load_offsets(state) |
+          last_commit: :erlang.monotonic_time(:milli_seconds)
+        }
+      else
+        state
+      end
 
     {:noreply, new_state, 0}
   end

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -388,9 +388,14 @@ defmodule KafkaEx.Server do
       end
 
       def kafka_server_metadata(topic, state) do
-        {correlation_id, metadata} = retrieve_metadata(state.brokers, state.correlation_id, config_sync_timeout(), topic)
-        updated_state = %{state | metadata: metadata, correlation_id: correlation_id}
-        {:reply, metadata, updated_state}
+        case retrieve_metadata(state.brokers, state.correlation_id, config_sync_timeout(), topic) do
+          {:error, reason} ->
+            {:stop, reason, state}
+
+          {correlation_id, metadata} ->
+            updated_state = %{state | metadata: metadata, correlation_id: correlation_id}
+            {:reply, metadata, updated_state}
+        end
       end
 
       def kafka_server_update_metadata(state) do

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -394,12 +394,17 @@ defmodule KafkaEx.Server do
       end
 
       def update_metadata(state) do
-        {correlation_id, metadata} = retrieve_metadata(state.brokers, state.correlation_id, config_sync_timeout())
-        metadata_brokers = metadata.brokers
-        brokers = state.brokers
-          |> remove_stale_brokers(metadata_brokers)
-          |> add_new_brokers(metadata_brokers, state.ssl_options, state.use_ssl)
-        %{state | metadata: metadata, brokers: brokers, correlation_id: correlation_id + 1}
+        case retrieve_metadata(state.brokers, state.correlation_id, config_sync_timeout()) do
+          {:error, reason} ->
+            state
+
+          {correlation_id, metadata} ->
+            metadata_brokers = metadata.brokers
+            brokers = state.brokers
+              |> remove_stale_brokers(metadata_brokers)
+              |> add_new_brokers(metadata_brokers, state.ssl_options, state.use_ssl)
+            %{state | metadata: metadata, brokers: brokers, correlation_id: correlation_id + 1}
+        end
       end
 
       # credo:disable-for-next-line Credo.Check.Refactor.FunctionArity

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -377,7 +377,9 @@ defmodule KafkaEx.Server do
       end
 
       # credo:disable-for-next-line Credo.Check.Refactor.FunctionArity
-      def retrieve_metadata(brokers, correlation_id, sync_timeout, topic \\ []), do: retrieve_metadata(brokers, correlation_id, sync_timeout, topic, @retry_count, 0)
+      def retrieve_metadata(brokers, correlation_id, sync_timeout, topic \\ []) do
+        retrieve_metadata(brokers, correlation_id, sync_timeout, topic, @retry_count, 0)
+      end
       # credo:disable-for-next-line Credo.Check.Refactor.FunctionArity
       def retrieve_metadata(_, correlation_id, _sync_timeout, topic, 0, error_code) do
         Logger.log(:error, "Metadata request for topic #{inspect topic} failed with error_code #{inspect error_code}")

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -37,6 +37,7 @@ defmodule KafkaEx.Server do
       worker_name: KafkaEx.Server,
       ssl_options: [],
       use_ssl: false,
+      uris: [],
       ready: false
     )
 
@@ -51,6 +52,7 @@ defmodule KafkaEx.Server do
       worker_name: atom,
       ssl_options: KafkaEx.ssl_options,
       use_ssl: boolean,
+      uris: [Broker.t],
       ready: boolean,
     }
 

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -218,6 +218,8 @@ defmodule KafkaEx.Server do
       @metadata_update_interval       30_000
       @sync_timeout                   1_000
       @ssl_options []
+      @startup_delay 100
+      @retry_delay 1000
 
       def init([args]) do
         kafka_server_init([args])

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -432,8 +432,7 @@ defmodule KafkaEx.Server do
         else
           message = "Unable to fetch metadata from any brokers. Timeout is #{sync_timeout}."
           Logger.log(:error, message)
-          raise message
-          :no_metadata_available
+          {:error, message}
         end
       end
 

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -73,6 +73,10 @@ defmodule KafkaEx.Server do
     {:ok, state, timeout | :hibernate} |
     :ignore |
     {:stop, reason :: any} when state: any
+  @callback kafka_server_connect(state :: State.t) ::
+    {:noreply, new_state} |
+    {:noreply, new_state, timeout | :hibernate} |
+    {:stop, reason :: term, new_state} when new_state: term
   @callback kafka_server_produce(request :: ProduceRequest.t, state :: State.t) ::
     {:reply, reply, new_state} |
     {:reply, reply, new_state, timeout | :hibernate} |
@@ -210,6 +214,10 @@ defmodule KafkaEx.Server do
 
       def init([args, name]) do
         kafka_server_init([args, name])
+      end
+
+      def handle_info(:init_server_connect, state) do
+        kafka_server_connect(state)
       end
 
       def handle_call(:consumer_group, _from, state) do

--- a/lib/kafka_ex/server_0_p_8_p_0.ex
+++ b/lib/kafka_ex/server_0_p_8_p_0.ex
@@ -37,6 +37,10 @@ defmodule KafkaEx.Server0P8P0 do
     {:ok, state}
   end
 
+  def kafka_server_connect(state) do
+    {:noreply, state}
+  end
+
   def start_link(args, name \\ __MODULE__)
 
   def start_link(args, :no_name) do

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -65,7 +65,10 @@ defmodule KafkaEx.Server0P8P2 do
     else
       {:ok, state}
     end
+  end
 
+  def kafka_server_connect(state) do
+    {:noreply, state}
   end
 
   def kafka_server_consumer_group(state) do

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -52,7 +52,15 @@ defmodule KafkaEx.Server0P8P2 do
 
     brokers = Enum.map(uris, fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port)} end)
     {correlation_id, metadata} = retrieve_metadata(brokers, 0, config_sync_timeout())
-    state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name}
+    state = %State{
+      metadata: metadata,
+      brokers: brokers,
+      correlation_id: correlation_id,
+      consumer_group: consumer_group,
+      metadata_update_interval: metadata_update_interval,
+      consumer_group_update_interval: consumer_group_update_interval,
+      worker_name: name
+    }
     # Get the initial "real" broker list and start a regular refresh cycle.
     state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -58,7 +58,6 @@ defmodule KafkaEx.Server0P9P0 do
     use_ssl = Keyword.get(args, :use_ssl, false)
     ssl_options = Keyword.get(args, :ssl_options, [])
 
-    brokers = Enum.map(uris, fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port, ssl_options, use_ssl)} end)
     {correlation_id, metadata} = retrieve_metadata(brokers, 0, config_sync_timeout())
     state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name, ssl_options: ssl_options, use_ssl: use_ssl}
     # Get the initial "real" broker list and start a regular refresh cycle.
@@ -74,6 +73,9 @@ defmodule KafkaEx.Server0P9P0 do
       else
         state
       end
+    brokers = Enum.map(uris,
+      fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port, ssl_options, use_ssl)} end
+    )
 
     {:ok, state}
   end

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -155,7 +155,7 @@ defmodule KafkaEx.Server0P9P0 do
       raise ConsumerGroupRequiredError, request
     end
 
-    {broker, state} = broker_for_consumer_group_with_update(state)
+    {broker, state} = broker_for_consumer_group_with_update(state, true)
 
     state_out = %{state | correlation_id: state.correlation_id + 1}
 

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -58,26 +58,47 @@ defmodule KafkaEx.Server0P9P0 do
     use_ssl = Keyword.get(args, :use_ssl, false)
     ssl_options = Keyword.get(args, :ssl_options, [])
 
-    {correlation_id, metadata} = retrieve_metadata(brokers, 0, config_sync_timeout())
-    state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name, ssl_options: ssl_options, use_ssl: use_ssl}
-    # Get the initial "real" broker list and start a regular refresh cycle.
-    state = update_metadata(state)
-    {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
-
-    state =
-      if consumer_group?(state) do
-        # If we are using consumer groups then initialize the state and start the update cycle
-        {_, updated_state} = update_consumer_metadata(state)
-        {:ok, _} = :timer.send_interval(state.consumer_group_update_interval, :update_consumer_metadata)
-        updated_state
-      else
-        state
-      end
     brokers = Enum.map(uris,
       fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port, ssl_options, use_ssl)} end
     )
 
+    state = %State{
+      brokers: brokers,
+      consumer_group: consumer_group,
+      metadata_update_interval: metadata_update_interval,
+      consumer_group_update_interval: consumer_group_update_interval,
+      worker_name: name,
+      ssl_options: ssl_options,
+      use_ssl: use_ssl
+    }
+
+    Process.send_after(self(), :init_server_connect, 1000)
+
     {:ok, state}
+  end
+
+  def kafka_server_connect(%State{brokers: brokers} = state) do
+    case retrieve_metadata(brokers, 0, config_sync_timeout()) do
+      {:error, _reason} ->
+        Process.send_after(self(), :init_server_connect, 1000)
+        {:noreply, state}
+
+      {correlation_id, metadata} ->
+        state = %State{state | metadata: metadata, correlation_id: correlation_id}
+        # Get the initial "real" broker list and start a regular refresh cycle.
+        state = update_metadata(state)
+        {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
+
+        if consumer_group?(state) do
+          # If we are using consumer groups then initialize the state and start the update cycle
+          {_, updated_state} = update_consumer_metadata(state)
+          {:ok, _} = :timer.send_interval(state.consumer_group_update_interval, :update_consumer_metadata)
+
+          {:noreply, updated_state}
+        else
+          {:noreply, state}
+        end
+    end
   end
 
   def kafka_server_join_group(request, network_timeout, state_in) do

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -69,7 +69,7 @@ defmodule KafkaEx.Server0P9P0 do
       uris: uris,
     }
 
-    Process.send_after(self(), :init_server_connect, 1000)
+    Process.send_after(self(), :init_server_connect, @startup_delay)
 
     {:ok, state}
   end
@@ -81,7 +81,7 @@ defmodule KafkaEx.Server0P9P0 do
 
     case retrieve_metadata(brokers, 0, config_sync_timeout()) do
       {:error, _reason} ->
-        Process.send_after(self(), :init_server_connect, 1000)
+        Process.send_after(self(), :init_server_connect, @retry_delay)
         {:noreply, state}
 
       {correlation_id, metadata} ->

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -58,7 +58,6 @@ defmodule KafkaEx.Server0P9P0 do
     use_ssl = Keyword.get(args, :use_ssl, false)
     ssl_options = Keyword.get(args, :ssl_options, [])
 
-
     state = %State{
       consumer_group: consumer_group,
       metadata_update_interval: metadata_update_interval,

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -94,7 +94,7 @@ defmodule KafkaEx.Server0P9P0 do
           {_, updated_state} = update_consumer_metadata(state)
           {:ok, _} = :timer.send_interval(state.consumer_group_update_interval, :update_consumer_metadata)
 
-          {:noreply, updated_state}
+          {:noreply, %{updated_state | ready: true}}
         else
           {:noreply, state}
         end

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -68,11 +68,13 @@ defmodule KafkaEx.Server0P9P0 do
       uris: uris,
     }
 
+    # sends to kafka_server_connect/1 callback
     Process.send_after(self(), :init_server_connect, @startup_delay)
 
     {:ok, state}
   end
 
+  # callback from :init_server_connect message
   def kafka_server_connect(%State{uris: uris, ssl_options: ssl_options, use_ssl: use_ssl} = state) do
     brokers = Enum.map(uris,
       fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port, ssl_options, use_ssl)} end


### PR DESCRIPTION
Initial POC of reconnection handling, attempting to solve https://github.com/kafkaex/kafka_ex/issues/298

Main change is to remove the `raise` if the broker cannot be found, but in doing that means the `init/1` has to return something, and if the host is not found it could return `{:error, reason}`, but that causes the `KafkaEx.ConsumerGroup.Manager` supervisor that calls it issues, should it then error as well?
Instead, I split the elixir boot sequence from the kafka connection, as the elixir startup should be successful regardless of outside influences and then handle connecting.

### TODO

- [ ] add tests
- [ ] rebase/squash
- [ ] check compliance with https://github.com/kafkaex/kafka_ex/blob/master/CONTRIBUTING.md
- [ ] raise PR on main repo https://github.com/kafkaex/kafka_ex